### PR TITLE
Fix simplechart submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "https-audit"]
 	path = https-audit
 	url = git@github.com:alleyinteractive/https-audit.git
-[submodule "simplechart"]
-	path = simplechart
-	url = git@github.com:alleyinteractive/simplechart.git
 [submodule "vip-https-support"]
 	path = vip-https-support
 	url = git@github.com:alleyinteractive/vip-https-support.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "vip-https-support"]
 	path = vip-https-support
 	url = git@github.com:alleyinteractive/vip-https-support.git
+[submodule "simplechart"]
+	path = simplechart
+	url = git@github.com:alleyinteractive/wordpress-simplechart.git


### PR DESCRIPTION
Replace 'simplechart' module with 'wordpress-simplechart', as should have been the case in the first place.